### PR TITLE
Handle the server exception 

### DIFF
--- a/resumo-web/app/controllers/application_controller.rb
+++ b/resumo-web/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 class ApplicationController < ActionController::API
   include ActionView::Rendering
   include ActionController::MimeResponds
+
+  rescue_from StandardError, with: :render_500
+
+  def render_500(exception)
+    render 'errors/500', locals: { exception: exception }, status: :internal_server_error
+  end
 end

--- a/resumo-web/app/views/errors/500.json.jbuilder
+++ b/resumo-web/app/views/errors/500.json.jbuilder
@@ -1,0 +1,3 @@
+json.status 500
+json.error "Internal Server Error"
+json.message exception.message


### PR DESCRIPTION
Currently return 500 if something went wrong

```json
{
    "status": 500,
    "error": "Internal Server Error",
    "message": "PDF does not contain EOF marker"
}
```